### PR TITLE
Xcode-15 intel fix

### DIFF
--- a/bindgen/src/builder.rs
+++ b/bindgen/src/builder.rs
@@ -59,6 +59,8 @@ impl Builder {
                 .path()
                 .to_str()
                 .expect("sdk path is not utf-8 representable"),
+            "-D__AVX512VLFP16INTRIN_H",
+            "-D__AVX512FP16INTRIN_H",
         ]);
 
         builder = builder


### PR DESCRIPTION
This effectively disables the C definitions (_Float16 _Complex ...) that trip bindgen inside avx512vlfp16intrin.h and avx512fp16intrin.h.

https://github.com/rust-lang/rust-bindgen/issues/2500#issuecomment-1640545912